### PR TITLE
Issue_5 Add Option Command

### DIFF
--- a/generate_lgtm.py
+++ b/generate_lgtm.py
@@ -10,11 +10,11 @@ class ImageOptions:
     text: str = "LGTM"
     font_path: str = "arial.ttf"
     font_size: int = 50
+    text_color: tuple = (255, 255, 255)
+    position: str = "center"
     text_x: int = None
     text_y: int = None
     output_path: str = None
-    text_color: tuple = (255, 255, 255)
-    position: str = "center"
 
 
 def parse_color(color_str: str) -> tuple | ValueError:
@@ -101,57 +101,69 @@ def add_lgtm_to_image(
 
 if __name__ == "__main__":
     # argparseでコマンドライン引数を解析
-    parser = argparse.ArgumentParser(description="Add text 'LGTM' to selected image.")
+    parser = argparse.ArgumentParser(
+        description="Add text 'LGTM' to selected image.",
+        usage="%(prog)s image_path [options]",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    # 必須の引数(ファイルパス)
     parser.add_argument(
         "image_path",
         help="The path to the image file",
     )
+
+    # テキスト関連のオプション
     parser.add_argument(
         "--text",
         "-t",
         default="LGTM",
-        help="The text to add to the image (default: LGTM)",
+        help="The text to add to the image",
     )
     parser.add_argument(
         "--font",
         "-f",
         default="arial.ttf",
-        help="The font file to use (default: arial.ttf)",
+        help="The font file to use",
     )
     parser.add_argument(
         "--size",
         "-s",
         type=int,
         default=50,
-        help="The font size of the text (default: 50)",
-    )
-    parser.add_argument(
-        "--x",
-        type=int,
-        help="The x position of the text (default: center)",
-    )
-    parser.add_argument(
-        "--y",
-        type=int,
-        help="The y position of the text (default: center)",
-    )
-    parser.add_argument(
-        "--output",
-        "-o",
-        help="The output file path (default: same as input with '_lgtm' suffix)",
+        help="The font size of the text",
     )
     parser.add_argument(
         "--color",
         "-c",
         default="white",
-        help="The color of the text (default: white)",
+        help="The color of the text",
     )
     parser.add_argument(
         "--position",
         "-p",
         choices=["top", "bottom", "center"],
         default="center",
-        help="Position of the text (top, bottom, center). Default is center.",
+        help="Position of the text (top, bottom, center).",
+    )
+
+    # テキストの位置指定用のオプション
+    parser.add_argument(
+        "--x",
+        type=int,
+        help="The x position of the text",
+    )
+    parser.add_argument(
+        "--y",
+        type=int,
+        help="The y position of the text",
+    )
+
+    # 出力関連のオプション
+    parser.add_argument(
+        "--output",
+        "-o",
+        help="The output file path. default output filename is same as input with '_lgtm' suffix.",
     )
 
     args = parser.parse_args()
@@ -164,11 +176,11 @@ if __name__ == "__main__":
         text=args.text,
         font_path=args.font,
         font_size=args.size,
+        text_color=text_color,
+        position=args.position,
         text_x=args.x,
         text_y=args.y,
         output_path=args.output,
-        text_color=text_color,
-        position=args.position,
     )
 
     # メソッドで画像処理

--- a/generate_lgtm.py
+++ b/generate_lgtm.py
@@ -1,9 +1,24 @@
 import os
 from PIL import Image, ImageDraw, ImageFont
-import sys
+import argparse
+from dataclasses import dataclass
 
 
-def add_lgtm_to_image(image_path):
+@dataclass
+class ImageOptions:
+    text: str = "LGTM"
+    font_path: str = "arial.ttf"
+    font_size: int = 50
+    text_x: int = None
+    text_y: int = None
+    output_path: str = None
+    text_color: str = "white"
+
+
+def add_lgtm_to_image(
+    image_path,
+    options: ImageOptions,
+):
     # 画像を開く
     image = Image.open(image_path).convert("RGB")
     draw = ImageDraw.Draw(image)
@@ -12,37 +27,101 @@ def add_lgtm_to_image(image_path):
     width, height = image.size
 
     # フォントとサイズを設定
-    # 画像の高さの20%の大きさ
-    font_size = int(height / 5)
     try:
-        font = ImageFont.truetype("arial.ttf", font_size)
+        font = ImageFont.truetype(options.font_path, options.font_size)
     except IOError:
+        print(f"Warning: Font '{options.font_path}' not found. Using default font.")
         font = ImageFont.load_default()
 
     # テキストのサイズを計算
-    text = "LGTM"
-    bbox = draw.textbbox((0, 0), text, font=font)
+    bbox = draw.textbbox((0, 0), options.text, font=font)
     text_width = bbox[2] - bbox[0]
     text_height = bbox[3] - bbox[1]
 
-    # テキストの位置を計算（中央に配置）
-    text_x = (width - text_width) / 2
-    text_y = (height - text_height) / 2
+    # テキストの位置を計算
+    text_x = options.text_x if options.text_x is not None else (width - text_width) / 2
+    text_y = (
+        options.text_y if options.text_y is not None else (height - text_height) / 2
+    )
 
-    # テキストを追加
-    draw.text((text_x, text_y), text, font=font, fill="white")
-
-    # JPEGで保存
-    file_name, _ = os.path.splitext(image_path)
-    output_path = f"{file_name}_lgtm.jpg"
+    # テキストを追加（文字色を設定）
+    draw.text((text_x, text_y), options.text, font=font, fill=options.text_color)
 
     # 画像を保存
+    output_path = (
+        options.output_path
+        if options.output_path
+        else f"{os.path.splitext(image_path)[0]}_lgtm.jpg"
+    )
     image.save(output_path, "JPEG")
-    print(f"Successfully generated the LGTM image. : {output_path}")
+    print(
+        f"Successfully generated the image with text '{options.text}'. \nOutput path: {output_path}"
+    )
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 2:
-        print("command: python generate_lgtm.py <image_path>")
-    else:
-        add_lgtm_to_image(sys.argv[1])
+    # argparseでコマンドライン引数を解析
+    parser = argparse.ArgumentParser(description="Add text 'LGTM' to selected image.")
+    parser.add_argument(
+        "image_path",
+        help="The path to the image file",
+    )
+    parser.add_argument(
+        "--text",
+        "-t",
+        default="LGTM",
+        help="The text to add to the image (default: LGTM)",
+    )
+    parser.add_argument(
+        "--font",
+        "-f",
+        default="arial.ttf",
+        help="The font file to use (default: arial.ttf)",
+    )
+    parser.add_argument(
+        "--size",
+        "-s",
+        type=int,
+        default=50,
+        help="The font size of the text (default: 50)",
+    )
+    parser.add_argument(
+        "--x",
+        type=int,
+        help="The x position of the text (default: center)",
+    )
+    parser.add_argument(
+        "--y",
+        type=int,
+        help="The y position of the text (default: center)",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        help="The output file path (default: same as input with '_lgtm' suffix)",
+    )
+    parser.add_argument(
+        "--color",
+        "-c",
+        default="white",
+        help="The color of the text (default: white)",
+    )
+
+    args = parser.parse_args()
+
+    # ImageOptionsオブジェクトを作成し、引数を設定
+    options = ImageOptions(
+        text=args.text,
+        font_path=args.font,
+        font_size=args.size,
+        text_x=args.x,
+        text_y=args.y,
+        output_path=args.output,
+        text_color=args.color,
+    )
+
+    # メソッドで画像処理
+    add_lgtm_to_image(
+        args.image_path,
+        options,
+    )

--- a/generate_lgtm.py
+++ b/generate_lgtm.py
@@ -14,6 +14,7 @@ class ImageOptions:
     text_y: int = None
     output_path: str = None
     text_color: tuple = (255, 255, 255)
+    position: str = "center"
 
 
 def parse_color(color_str: str) -> tuple | ValueError:
@@ -67,9 +68,16 @@ def add_lgtm_to_image(
 
     # テキストの位置を計算
     text_x = options.text_x if options.text_x is not None else (width - text_width) / 2
-    text_y = (
-        options.text_y if options.text_y is not None else (height - text_height) / 2
-    )
+
+    # `--position` オプションに基づいてY座標を計算
+    if options.position == "top":
+        text_y = 10
+    elif options.position == "bottom":
+        text_y = height - text_height - 25
+    else:
+        text_y = (
+            options.text_y if options.text_y is not None else (height - text_height) / 2
+        )
 
     # テキストを追加（文字色を設定）
     draw.text(
@@ -138,6 +146,13 @@ if __name__ == "__main__":
         default="white",
         help="The color of the text (default: white)",
     )
+    parser.add_argument(
+        "--position",
+        "-p",
+        choices=["top", "bottom", "center"],
+        default="center",
+        help="Position of the text (top, bottom, center). Default is center.",
+    )
 
     args = parser.parse_args()
 
@@ -153,6 +168,7 @@ if __name__ == "__main__":
         text_y=args.y,
         output_path=args.output,
         text_color=text_color,
+        position=args.position,
     )
 
     # メソッドで画像処理


### PR DESCRIPTION
featured #5 

- オプション機能を追加


## コマンドラインオプションの追加および整理

このPRでは、以下のコマンドラインオプションを`argparse`を使って追加および整理しました。オプションを活用することで、画像に対してカスタマイズ可能なテキストを追加できるようになっています。

### 基本的なコマンドの構成

`generate_lgtm.py` では、以下のようなコマンドを実行して画像にテキストを追加できます。

```bash
python generate_lgtm.py image_path [options]
```

- `image_path`: 画像ファイルのパス（必須）
- `[options]`: オプションとしてテキスト、フォント、サイズ、色、位置、出力パスなどが指定可能

### オプション一覧

以下のオプションを利用して、テキストのスタイルや位置、出力ファイル名を指定できます。

#### テキスト関連のオプション

| オプション  | 説明 |
| ----------- | ---- |
| `--text`, `-t` | 追加するテキストを指定します。デフォルトは `"LGTM"` です。 |
| `--font`, `-f` | 使用するフォントファイルを指定します。デフォルトは `"arial.ttf"` です。 |
| `--size`, `-s` | フォントサイズを指定します。デフォルトは `50` です。 |
| `--color`, `-c` | テキストの色を指定します。カラー名（例: `"red"`）またはRGBタプル（例: `"(255, 0, 0)"`）、16進数カラーコード（例: `"#FF0000"`）を使用できます。デフォルトは `"white"` です。 |
| `--position`, `-p` | テキストの垂直方向の配置を指定します。`"top"`、`"bottom"`、`"center"` から選べます。デフォルトは `"center"` です。 |

#### テキストの位置指定用のオプション

| オプション | 説明 |
| ---------- | ---- |
| `--x` | テキストのX座標を指定します。デフォルトは画像の中央です。 |
| `--y` | テキストのY座標を指定します。デフォルトは画像の中央です。 |

#### 出力関連のオプション

| オプション | 説明 |
| ---------- | ---- |
| `--output`, `-o` | 出力する画像ファイルのパスを指定します。指定しない場合は元のファイル名に`"_lgtm"`が付加されます。 |

### 使用例

#### 基本的な使用例

以下のコマンドは、画像 `input.jpg` に `"Hello World"` というテキストを中央に追加し、`output.jpg` というファイル名で保存します。

```bash
python generate_lgtm.py input.jpg --text "Hello World" --output output.jpg
```

#### テキストのカスタマイズ例

以下のコマンドは、フォント、色、サイズ、位置を指定して画像にテキストを追加します。

```bash
python generate_lgtm.py input.png --text "Welcome!" --font "CustomFont.ttf" --size 100 --color "(255, 0, 0)" --position top --output welcome_image.png
```

### 追加した機能

- `image_path` を必須の引数として追加し、画像ファイルのパスを指定可能にしました。
- テキストに関するカスタマイズオプション（`--text`, `--font`, `--size`, `--color`, `--position`）を追加しました。
- テキストの位置を微調整するための `--x`, `--y` オプションを追加しました。
- 出力ファイルのパスを指定する `--output` オプションを追加しました。

### ヘルプメッセージ

以下は、`--help` オプションを使用した際に表示されるヘルプメッセージです。

```bash
usage: generate_lgtm.py image_path [options]

Add text 'LGTM' to selected image.

positional arguments:
  image_path            The path to the image file

optional arguments:
  -h, --help            show this help message and exit

# テキスト関連のオプション:
  --text TEXT, -t TEXT  The text to add to the image (default: LGTM)
  --font FONT, -f FONT  The font file to use (default: arial.ttf)
  --size SIZE, -s SIZE  The font size of the text (default: 50)
  --color COLOR, -c COLOR
                        The color of the text (default: white)
  --position {top,bottom,center}, -p {top,bottom,center}
                        Position of the text (default: center)

# テキスト位置のオプション:
  --x X                 The x position of the text (default: center)
  --y Y                 The y position of the text (default: center)

# 出力関連のオプション:
  --output OUTPUT, -o OUTPUT
                        The output file path (default: None)
```
